### PR TITLE
Update version-select.js for Material for Mkdocs 5

### DIFF
--- a/mike/themes/material/js/version-select.js
+++ b/mike/themes/material/js/version-select.js
@@ -1,49 +1,46 @@
 window.addEventListener("DOMContentLoaded", function() {
-  // This is a bit hacky. Figure out the base URL from a known CSS file the
-  // template refers to...
-  var ex = new RegExp("/?assets/fonts/material-icons.css$");
-  var sheet = document.querySelector('link[href$="material-icons.css"]');
-
-  var ABS_BASE_URL = sheet.href.replace(ex, "");
-  var CURRENT_VERSION = ABS_BASE_URL.split("/").pop();
-
+  var VERSION = window.location.pathname.split('/')[1];
+  
   function makeSelect(options, selected) {
-    var select = document.createElement("select");
-    select.classList.add("form-control");
-
-    options.forEach(function(i) {
-      var option = new Option(i.text, i.value, undefined,
-                              i.value === selected);
-      select.add(option);
-    });
-
-    return select;
+      var select = document.createElement("select");
+      select.classList.add("form-control");
+  
+      options.forEach(function(i) {
+          var option = new Option(i.text, "/" + i.value, undefined,
+                                  i.value === selected);
+          select.add(option);
+      });
+  
+      return select;
   }
-
+  
   var xhr = new XMLHttpRequest();
-  xhr.open("GET", ABS_BASE_URL + "/../versions.json");
+  // Obtain JSON listing all available versions
+  xhr.open("GET", window.location.origin + "/versions.json");
   xhr.onload = function() {
-    var versions = JSON.parse(this.responseText);
+      var versions = JSON.parse(this.responseText);
+  
+      // Identify which is the current version
+      var currentVersion = versions.find(function(i) {
+          return i.version === VERSION ||
+                 i.aliases.includes(VERSION)
+      }).version;
 
-    var realVersion = versions.find(function(i) {
-      return i.version === CURRENT_VERSION ||
-             i.aliases.includes(CURRENT_VERSION);
-    }).version;
-
-    var select = makeSelect(versions.map(function(i) {
-      return {text: i.title, value: i.version};
-    }), realVersion);
-    select.addEventListener("change", function(event) {
-      window.location.href = ABS_BASE_URL + "/../" + this.value;
-    });
-
-    var container = document.createElement("div");
-    container.id = "version-selector";
-    container.className = "md-nav__item";
-    container.appendChild(select);
-
-    var sidebar = document.querySelector(".md-nav--primary > .md-nav__list");
-    sidebar.parentNode.insertBefore(container, sidebar);
+      var select = makeSelect(versions.map(function(i) {
+          return {text: i.title, value: i.version};
+      }), currentVersion);
+  
+      select.addEventListener("change", function(event) {
+          window.location.href = window.location.origin + this.value;
+      });
+  
+      var container = document.createElement("div");
+      container.id = "version-selector";
+      container.className = "md-nav__item";
+      container.appendChild(select);
+  
+      var sidebar = document.querySelector(".md-nav--primary > .md-nav__list");
+      sidebar.parentNode.insertBefore(container, sidebar);
   };
   xhr.send();
 });


### PR DESCRIPTION
The file `material-icons.css` no longer exists on Material for Mkdocs 5, causing the current JavaScript to fail.

My implementation uses instead the `window.location.pathname` to infer the version.