### PR TITLE
Update CI instructions with git fetch and git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,20 +234,27 @@ live), and commit the necessary files to the root directory.
 ## Deploying via CI
 
 Since mike just generates commits to an ordinary git branch, it should work
-smoothly with your favorite CI system. However, you should keep in mind that
-some CI systems make shallow clones of your repository, meaning that the CI job
-won't have a local instance of your documentation branch to commit to. This will
-naturally cause issues when trying to push the commit. This is easy to resolve
-though. For Github Actions, you can simply disable shallow clones:
+smoothly with your favorite CI system. 
 
-```yaml
-jobs:
-  deploy-docs:
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # fetch all commits/branches
-      # ...
+However, you should keep in mind that some CI systems make shallow clones of
+your repository with only the current commit, meaning that the CI job won't have
+a local instance of your documentation branch to commit to. This will naturally
+cause issues when trying to push the commit. This is easy to resolve though. You
+can simply manually fetch your `gh-pages` branch (or whichever you deploy to)
+before running your deploy.
+
+```bash
+git fetch origin gh-pages --depth=1
+```
+
+You may also need to set a git user so that mike can make commits. Simply
+use [`git config` command](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup#_your_identity)
+to do so. If you're using GitHub Actions, you can impersonate the 
+`github-actions[bot]` user with the following config commands:
+
+```bash
+git config user.name github-actions[bot]
+git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 ```
 
 ## For Theme Authors


### PR DESCRIPTION
Hello, I've recently been experimenting with getting mike to work with GitHub Actions, and I have some suggested improvements to the README.

- I found that manually calling `git fetch` for just the head commit on the `gh-pages` branch was good enough. I think this is preferable to setting `fetch-depth: 0`, which can lead to a lot of unnecessary data transfer for repos with a large disk footprint, a long history, and/or many branches. 
- The need to configure the git user was undocumented. I've seen examples in various issues using `git config --global`, but actually just `git config` for the current repository was enough. 

[My example](https://github.com/jayqi/github-actions-sandbox/blob/1369dc2236dc93660aa35e2964112043fb9060e4/.github/workflows/docs-main.yml#L32-L35) for reference.

Thank you for creating and maintaining this nifty tool!