### PR TITLE
Fix mkdocs.yaml support

### DIFF
--- a/mike/driver.py
+++ b/mike/driver.py
@@ -59,7 +59,7 @@ def add_git_arguments(parser, *, commit=True, prefix=True):
     # Add this whenever we add git arguments since we pull the remote and
     # branch from mkdocs.yml.
     parser.add_argument('-F', '--config-file', metavar='FILE',
-                        default='mkdocs.yml', complete='file',
+                        default=None, complete='file',
                         help='the MkDocs configuration file to use')
 
     git = parser.add_argument_group('git arguments')


### PR DESCRIPTION
I found `mike` doesn't work with `mkdocs.yaml`.

It seems `mkdocs.yaml` support is introduced in 494147af622e6ed02216d5f1b58d763cbe546ba8, but it's not working because the default value is set.

### How to test

```sh-session
$ git clone git@github.com:kenji-miyake/mike.git
$ cd mike
$ wget https://github.com/squidfunk/mkdocs-material/raw/master/mkdocs.yml
$ pip install -e .
$ mike list
ERROR   -  Config value: 'docs_dir'. Error: The path docs isn't an existing directory.
ERROR   -  Config value: 'plugins'. Error: The "redirects" plugin is not installed
error: Aborted with 2 Configuration Errors!

$ mv mkdocs.yml mkdocs.yaml
$ mike list
error: [Errno 2] No such file or directory: 'mkdocs.yml'; pass --config-file or set --remote/--branch explicitly

$ git checkout fix-mkdocs-yaml-support
$ mike list
ERROR   -  Config value: 'docs_dir'. Error: The path docs isn't an existing directory.
ERROR   -  Config value: 'plugins'. Error: The "redirects" plugin is not installed
error: Aborted with 2 Configuration Errors!
