### PR TITLE
Format version.json

### DIFF
--- a/mike/versions.py
+++ b/mike/versions.py
@@ -73,7 +73,7 @@ class Versions:
         return result
 
     def dumps(self):
-        return json.dumps([i.to_json() for i in iter(self)])
+        return json.dumps([i.to_json() for i in iter(self)], indent=2)
 
     def __iter__(self):
         return (i for _, i in sorted(self._data.items(), reverse=True))


### PR DESCRIPTION
I think it would useful to format `versions.json` in order to make the diff clear.

Left: Before
Right: After
![image](https://user-images.githubusercontent.com/31987104/156762585-7356535d-0e40-436b-bd72-336736042682.png)

With this, we can easily find what has changed.
For example, after `mike deploy main latest`:

![image](https://user-images.githubusercontent.com/31987104/156762656-a8fbf5eb-e8f7-45a1-be00-be58de1028d6.png)
