### PR TITLE
use jinja2 < 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
     packages=find_packages(exclude=['test', 'test.*']),
     include_package_data=True,
 
-    install_requires=(['mkdocs >= 1.0', 'jinja2', 'pyyaml >= 5.1', 'verspec']),
+    install_requires=(['mkdocs >= 1.0', 'jinja2<3.0.0', 'pyyaml >= 5.1', 'verspec']),
     extras_require={
         'dev': ['coverage', 'flake8 >= 3.0', 'flake8-quotes', 'shtab'],
         'test': ['coverage', 'flake8 >= 3.0', 'flake8-quotes', 'shtab'],


### PR DESCRIPTION
Using Python 3.9.0 and 3.10.0 with a fresh environment causes this error:
```
Traceback (most recent call last):
  File "/Users/atsai/.pyenv/versions/silver-memory-3.9.0/bin/mkdocs", line 8, in <module>
    sys.exit(cli())
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/mkdocs/__main__.py", line 187, in build_command
    build.build(config.load_config(**kwargs), dirty=not clean)
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/mkdocs/config/base.py", line 216, in load_config
    from mkdocs.config.defaults import get_schema
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/mkdocs/config/defaults.py", line 1, in <module>
    from mkdocs.config import config_options
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/mkdocs/config/config_options.py", line 8, in <module>
    from mkdocs import utils, theme, plugins
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/mkdocs/theme.py", line 6, in <module>
    from mkdocs.utils import filters
  File "/Users/atsai/.pyenv/versions/3.9.0/envs/silver-memory-3.9.0/lib/python3.9/site-packages/mkdocs/utils/filters.py", line 13, in <module>
    @jinja2.contextfilter
AttributeError: module 'jinja2' has no attribute 'contextfilter'
mike: Command '['mkdocs', 'build', '--clean', '--config-file', 'mkdocs.yml']' returned non-zero exit status 1.
```

In `jinja2` documentation they referenced the deprecation of `contextfilter` and currently `setup.py` is not configured for a specific version.

https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.pass_context