### PR TITLE
Fix generated text-files

### DIFF
--- a/mike/commands.py
+++ b/mike/commands.py
@@ -18,7 +18,8 @@ def _redirect_template(user_template=None):
     f = (open(user_template, 'rb') if user_template else
          resource_stream(__name__, 'templates/redirect.html'))
     with f:
-        return Template(f.read().decode('utf-8'), autoescape=True)
+        return Template(f.read().decode('utf-8'), autoescape=True,
+                        keep_trailing_newline=True)
 
 
 def _add_redirect_to_commit(commit, template, src, dst,

--- a/mike/versions.py
+++ b/mike/versions.py
@@ -73,7 +73,7 @@ class Versions:
         return result
 
     def dumps(self):
-        return json.dumps([i.to_json() for i in iter(self)], indent=2)
+        return json.dumps([i.to_json() for i in iter(self)], indent=2) + '\n'
 
     def __iter__(self):
         return (i for _, i in sorted(self._data.items(), reverse=True))

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,8 @@ setup(
     packages=find_packages(exclude=['test', 'test.*']),
     include_package_data=True,
 
-    install_requires=(['mkdocs >= 1.0', 'jinja2', 'pyyaml >= 5.1', 'verspec']),
+    install_requires=(['mkdocs >= 1.0', 'jinja2 >= 2.7', 'pyyaml >= 5.1',
+                       'verspec']),
     extras_require={
         'dev': ['coverage', 'flake8 >= 3.0', 'flake8-quotes', 'shtab'],
         'test': ['coverage', 'flake8 >= 3.0', 'flake8-quotes', 'shtab'],

--- a/test/integration/test_alias.py
+++ b/test/integration/test_alias.py
@@ -87,7 +87,7 @@ class TestAlias(AliasTestCase):
         self._test_alias()
 
         with open('latest/index.html') as f:
-            self.assertEqual(f.read(), 'Redirecting to ../1.0/')
+            self.assertEqual(f.read(), 'Redirecting to ../1.0/\n')
 
     def test_from_subdir(self):
         self._deploy()

--- a/test/integration/test_deploy.py
+++ b/test/integration/test_deploy.py
@@ -85,7 +85,7 @@ class TestDeploy(DeployTestCase):
         check_call_silent(['git', 'checkout', 'gh-pages'])
 
         with open('latest/index.html') as f:
-            self.assertEqual(f.read(), 'Redirecting to ../1.0/')
+            self.assertEqual(f.read(), 'Redirecting to ../1.0/\n')
 
     def test_update(self):
         assertPopen(['mike', 'deploy', '1.0', 'latest'])


### PR DESCRIPTION
Text files generated (from redirect templates and versions.json) are missing trailing newlines ("No newline at end of file").

Missing in the sense that `git diff` and similar operations are emitting such diagnostic messages.

The issue is with these kinds of files:

- Redirect html files generated from the redirect template
- versions.json

Fix is to add a newline (U000A LINE FEED (LF) \n) at the end of file. It is verbatim as git stores text-files with the \n line separator internally and these buffers are used as file-data in `git-fast-import`.