### PR TITLE
fix: bug when `user.name` is not set in git config

### DIFF
--- a/mike/git_utils.py
+++ b/mike/git_utils.py
@@ -207,12 +207,14 @@ class Commit:
     def _start_commit(self, branch, message):
         encoding = get_commit_encoding()
 
-        name = os.getenv('GIT_COMMITTER_NAME',
-                         get_config('user.name', encoding))
+        name = os.getenv('GIT_COMMITTER_NAME')
+        if not name:
+            name = get_config('user.name', encoding)
         name = re.sub(r'[<>\n]', '', name)
 
-        email = os.getenv('GIT_COMMITTER_EMAIL',
-                          get_config('user.email', encoding))
+        email = os.getenv('GIT_COMMITTER_EMAIL')
+        if not email:
+            email = get_config('user.email', encoding)
         email = re.sub(r'[<>\n]', '', email)
 
         when = os.getenv('GIT_COMMITTER_DATE', make_when())


### PR DESCRIPTION
Hey, I hit this error with 1.1.2:

```
GIT_COMMITTER_NAME=ci-bot GIT_COMMITTER_EMAIL=ci-bot@example.com mike deploy v1 latest
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: TRUNCATED/docs/build/site
INFO     -  Documentation built in 0.40 seconds
error: error getting config 'user.name'
```

Indeed, I never setup my git informations into my git config, I always use environment variables, as I work for different companies, and I don't want to take the chance for my identities to leak across customers. As the key does not exists in my config, it make fails the deployment. So the case you documented in the README.md does not work.

There is a fix attached :D It fixes this commit : https://github.com/jimporter/mike/commit/2faa33ca4cf0da62c9c0ac7fbe8b60688733d7f1


Side question: last release is 14m old, any plans to release a new version soon ? I'd like to fix: 
```
mike = {git = "https://github.com/jimporter/mike", rev = "master"}
```
in favor of:
```
mike = "^1.1.3"
```

Thanks for your great work :)