### PR TITLE
fix incorrect positional argument description of `delete`

### DIFF
--- a/mike/driver.py
+++ b/mike/driver.py
@@ -281,7 +281,7 @@ def main():
                           help='delete everything')
     add_git_arguments(delete_p)
     delete_p.add_argument('version', nargs='*', metavar='VERSION',
-                          help='version (directory) to delete')
+                          help='version (directory) or alias to delete')
 
     alias_p = subparsers.add_parser(
         'alias', description=alias_desc, help='alias docs from a branch'


### PR DESCRIPTION
Just found this while trying to delete a version. The README uses version-or-alias but the description did not.