### PR TITLE
Allow new versions to replace existing aliases when `--update-aliases` is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ pre-existing aliases for it. Normally, if an alias specified on the command line
 is already associated with another version, this will return an error. If you
 *do* want to move an alias from another version to this version (e.g. when
 releasing a new version and updating the `latest` alias to point to this new
-version), you can pass `-u`/`--update-aliases` to allow this.
+version) or the new version was previously an alias (e.g. when you used the
+future release name as an alias for development builds), you can pass
+`-u`/`--update-aliases` to allow this.
 
 By default, each alias creates a symbolic link to the base directory of the real
 version of the docs; to create a copy of the docs for each alias, you can pass

--- a/mike/versions.py
+++ b/mike/versions.py
@@ -128,8 +128,14 @@ class Versions:
         if v in self._data:
             self._data[v].update(title, aliases)
         else:
-            if self.find(version):
-                raise ValueError('version {!r} already exists'.format(version))
+            find = self.find(version)
+            if find:
+                if update_aliases:
+                    removed_aliases.append(find)
+                else:
+                    raise ValueError(
+                        'version {!r} already exists'.format(version)
+                    )
             self._data[v] = VersionInfo(version, title, aliases)
 
         # Remove aliases from old versions that we've moved to this version.

--- a/test/integration/test_deploy.py
+++ b/test/integration/test_deploy.py
@@ -122,6 +122,15 @@ class TestDeploy(DeployTestCase):
             versions.VersionInfo('1.0'),
         ])
 
+    def test_update_aliases_for_release(self):
+        assertPopen(['mike', 'deploy', '1.0-beta', '1.0'])
+        assertPopen(['mike', 'deploy', '1.0', 'latest', '-u'])
+        check_call_silent(['git', 'checkout', 'gh-pages'])
+        self._test_deploy(expected_versions=[
+            versions.VersionInfo('1.0', aliases=['latest']),
+            versions.VersionInfo('1.0-beta'),
+        ])
+
     def test_from_subdir(self):
         os.mkdir('sub')
         with pushd('sub'):

--- a/test/unit/test_versions.py
+++ b/test/unit/test_versions.py
@@ -289,8 +289,15 @@ class TestVersions(unittest.TestCase):
         msg = r"version '1\.0' already exists"
         with self.assertRaisesRegex(ValueError, msg):
             versions.add('1.0')
-        with self.assertRaisesRegex(ValueError, msg):
-            versions.add('1.0', update_aliases=True)
+
+    def test_add_overwrite_alias_with_version_and_update_aliases(self):
+        versions = Versions()
+        versions.add('1.0b1', aliases=['1.0'])
+        versions.add('1.0', update_aliases=True)
+        self.assertEqual(list(versions), [
+            VersionInfo('1.0'),
+            VersionInfo('1.0b1'),
+        ])
 
     def test_add_invalid(self):
         versions = Versions()


### PR DESCRIPTION
Hello, I'm a developer at [BetonQuest](https://github.com/BetonQuest). Currently, we use `2.0-DEV` for development versions and `2.0` as an alias.

This pull request enhances the `--update-aliases` flag by allowing it to overwrite existing aliases with a new version.
Previously one had to first remove the alias to then create a new version with the same name.

Example based on our case:
1. Assume you have a version `2.0-DEV` and an alias `2.0` pointing to that version.
2. You run `mike deploy 2.0 --update-aliases`.
3. With this change you will end up with two versions: `2.0-DEV` and `2.0`, `2.0` is now not an alias of `2.0-DEV` anymore.
   Without this change `mike` would throw an exception.