### PR TITLE
feat: executable with `python -m mike`

### DIFF
--- a/mike/__main__.py
+++ b/mike/__main__.py
@@ -1,0 +1,4 @@
+from mike.driver import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Problem

In setup-python actions https://github.com/actions/setup-python, you can cache the requirements and it will restore the python packages in the next run.  
However, it won't restore the commands stored in the `bin` folder. Thus I can't execute mike with the cached installation afterwards.

### Solution

I want to make mike executable with `python -m mike`, just like `python -m mkdocs`.

### Example GitHub Actions

```yaml
name: Deploy docs

on:
  push:
    branches:
      - main

jobs:
  mkdocs:
    runs-on: ubuntu-latest
    environment: mkdocs

    steps:
      - uses: actions/checkout@v4
      - name: Set up Python
        uses: actions/setup-python@v5
        id: setup-python
        with:
          python-version-file: pyproject.toml
          cache: 'pip'
          cache-dependency-path: |
            requirements_docs.txt
      - name: Install dependencies
        if: steps.setup-python.outputs.cache-hit != 'true'
        run: |
          python -m pip install --upgrade pip
          pip3 install -r requirements_docs.txt
      - name: Run mkdocs
        run: |
          python -m mike deploy latest
```