### PR TITLE
serve: display deploy_prefix in the URL

### DIFF
--- a/mike/commands.py
+++ b/mike/commands.py
@@ -296,7 +296,8 @@ def set_default(identifier, template=None, *, branch='gh-pages', message=None,
         ))
 
 
-def serve(address='localhost:8000', *, branch='gh-pages', verbose=True):
+def serve(address='localhost:8000', *, branch='gh-pages', deploy_prefix='',
+          verbose=True):
     my_branch = branch
 
     class Handler(server.GitBranchHTTPHandler):
@@ -307,7 +308,7 @@ def serve(address='localhost:8000', *, branch='gh-pages', verbose=True):
     httpd = http.server.HTTPServer((host, port), Handler)
 
     if verbose:
-        print('Starting server at http://{}:{}/'.format(host, port))
+        print('Starting server at http://{}:{}/{}'.format(host, port, deploy_prefix))
         print('Press Ctrl+C to quit.')
     try:
         httpd.serve_forever()

--- a/mike/driver.py
+++ b/mike/driver.py
@@ -309,7 +309,9 @@ def set_default(parser, args):
 def serve(parser, args):
     load_mkdocs_config(args)
     check_remote_status(args)
-    commands.serve(args.dev_addr, branch=args.branch)
+    commands.serve(args.dev_addr,
+                   branch=args.branch,
+                   deploy_prefix=args.deploy_prefix)
 
 
 def help(parser, args):
@@ -432,7 +434,7 @@ def main():
         'serve', description=serve_desc, help='serve docs locally for testing'
     )
     serve_p.set_defaults(func=serve)
-    add_git_arguments(serve_p, commit=False, deploy_prefix=False)
+    add_git_arguments(serve_p, commit=False)
     serve_p.add_argument('-a', '--dev-addr', default='localhost:8000',
                          metavar='HOST[:PORT]',
                          help=('Host address and port to serve from ' +


### PR DESCRIPTION
otherwise it’s kind of non-obvious why the development mode is not working.
It is but on a path ;)