### PR TITLE
Support aliased mkdocs executables

### DIFF
--- a/mike/mkdocs_utils.py
+++ b/mike/mkdocs_utils.py
@@ -89,5 +89,5 @@ def version():
         ['mkdocs', '--version'],
         check=True, stdout=subprocess.PIPE, universal_newlines=True
     ).stdout.rstrip()
-    m = re.search('^mkdocs, version (\\S*)', output)
+    m = re.search('^.*?, version (\\S*)', output)
     return m.group(1)


### PR DESCRIPTION
Sometimes the mkdocs executable is not called `mkdocs`