### PR TITLE
feat(deploy): added a `--set-default` flag to set the deployed version the new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ the setting of `alias_type`/`--alias-type`.)
 Like `deploy` and `delete` above, you can specify `--branch`, `--push`,
 etc to control how the commit is handled.
 
+As with `deploy`, you can pass `-d`/`--set-default` to set the published version
+as the new default.
+
 ### Changing a Version's Title
 
 As you update your docs, you may want to change the title of a particular

--- a/mike/commands.py
+++ b/mike/commands.py
@@ -62,7 +62,8 @@ def make_nojekyll():
 @contextmanager
 def deploy(cfg, version, title=None, aliases=[], update_aliases=False,
            alias_type=AliasType.symlink, template=None, *, branch='gh-pages',
-           message=None, allow_empty=False, deploy_prefix='', set_props=[]):
+           message=None, allow_empty=False, deploy_prefix='', set_props=[], 
+           set_default=False):
     if message is None:
         message = (
             'Deployed {rev} to {doc_version}{deploy_prefix} with MkDocs ' +
@@ -117,6 +118,13 @@ def deploy(cfg, version, title=None, aliases=[], update_aliases=False,
 
         commit.add_file(versions_to_file_info(all_versions, deploy_prefix))
         commit.add_file(make_nojekyll())
+
+        if set_default:
+            t = _redirect_template(template)
+            commit.add_file(git_utils.FileInfo(
+                os.path.join(deploy_prefix, 'index.html'),
+                t.render(href=version_str + '/')
+            ))
 
 
 def delete(identifiers=None, all=False, *, branch='gh-pages', message=None,

--- a/mike/driver.py
+++ b/mike/driver.py
@@ -196,7 +196,8 @@ def deploy(parser, args):
                              branch=args.branch, message=args.message,
                              allow_empty=args.allow_empty,
                              deploy_prefix=args.deploy_prefix,
-                             set_props=args.set_props or []), \
+                             set_props=args.set_props or [],
+                             set_default=args.set_default), \
              mkdocs_utils.inject_plugin(args.config_file) as config_file:
             mkdocs_utils.build(config_file, args.version)
         if args.push:
@@ -350,6 +351,8 @@ def main():
                                 '%(choices)s; default: symlink)'))
     deploy_p.add_argument('-T', '--template', complete='file',
                           help='template file to use for redirects')
+    deploy_p.add_argument('-d', '--set-default', action='store_true',
+                          help='set the deployed version as the new default')
     add_git_arguments(deploy_p)
     add_set_prop_arguments(deploy_p, prefix='prop-')
     deploy_p.add_argument('version', metavar='VERSION',

--- a/test/integration/test_deploy.py
+++ b/test/integration/test_deploy.py
@@ -141,6 +141,15 @@ class TestDeploy(DeployTestCase):
             versions.VersionInfo('1.0b1'),
         ])
 
+    def test_set_default(self):
+        assertPopen(['mike', 'deploy', '1.0', '--set-default'])
+        check_call_silent(['git', 'checkout', 'gh-pages'])
+        self._test_deploy(expected_versions=[
+            versions.VersionInfo('1.0'),
+        ])
+        with open('index.html') as f:
+            self.assertRegex(f.read(), match_redir('1.0/'))
+
     def test_from_subdir(self):
         os.mkdir('sub')
         with pushd('sub'):


### PR DESCRIPTION
Hi 👋🏼 

Given I haven't a CONTRIBUTING file or any contribution process in the README, I allowed myself to submit a pull request.

This pull request adds a `--set-default/-d` flag to the `deploy` command, allowing to set the published version as the new default.
Documentation/README has been updated accordingly, and related tests have been added.