### PR TITLE
Add `--` to `count_reachable` cmd

### DIFF
--- a/mike/git_utils.py
+++ b/mike/git_utils.py
@@ -85,7 +85,7 @@ def get_latest_commit(rev, *, short=False):
 
 
 def count_reachable(rev):
-    cmd = ['git', 'rev-list', '--count', rev]
+    cmd = ['git', 'rev-list', '--count', rev, '--']
     p = sp.run(cmd, stdout=sp.PIPE, stderr=sp.PIPE, universal_newlines=True)
     if p.returncode == 0:
         return int(p.stdout.strip())


### PR DESCRIPTION
I am getting:

```
error: unable to get number of reachable commits from docs:
  fatal: ambiguous argument 'docs': both revision and filename
  Use '--' to separate paths from revisions, like this:
  'git <command> [<revision>...] -- [<file>...]'
make: *** [.makefiles/docs.mk:24: docs/build-version-release] Error 1
```

Originating from [`count_reachable`](https://github.com/jimporter/mike/blob/9291efbd6961d652c16c000dc1fe4f2f1e19f94c/mike/git_utils.py#L87-L94).

My repo is structured s.t. we have both a `docs/` folder and a `docs` branch, leading to the above error. As suggested in the `git` error message, by adding `--` to clarify that we are specifying a revision, I am able to resolve this. I confirmed this by testing locally:

```console
$ git rev-list --count docs
fatal: ambiguous argument 'docs': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
$ git rev-list --count docs --
2028
```