### PR TITLE
Use deploy prefix when deleting previous versions during deployment

### DIFF
--- a/mike/commands.py
+++ b/mike/commands.py
@@ -91,7 +91,7 @@ def deploy(cfg, version, title=None, aliases=[], update_aliases=False,
         t = _redirect_template(template)
 
     with git_utils.Commit(branch, message, allow_empty=allow_empty) as commit:
-        commit.delete_files([version_str] + list(info.aliases))
+        commit.delete_files([destdir] + alias_destdirs)
 
         for f in git_utils.walk_real_files(cfg['site_dir']):
             canonical_file = f.copy(destdir, cfg['site_dir'])

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -84,7 +84,7 @@ def git_config():
 
 
 def git_init():
-    check_call_silent(['git', 'init'])
+    check_call_silent(['git', 'init', '--initial-branch=master'])
     git_config()
 
 

--- a/test/integration/test_deploy.py
+++ b/test/integration/test_deploy.py
@@ -164,6 +164,13 @@ class TestDeploy(DeployTestCase):
         check_call_silent(['git', 'checkout', 'gh-pages'])
         self._test_deploy(directory='prefix')
 
+    def test_double_deploy_prefix(self):
+        assertPopen(['mike', 'deploy', '1.0'])
+        assertPopen(['mike', 'deploy', '1.0', '--deploy-prefix', 'prefix'])
+        check_call_silent(['git', 'checkout', 'gh-pages'])
+        self._test_deploy()
+        self._test_deploy(directory='prefix')
+
     def test_push(self):
         check_call_silent(['git', 'config', 'receive.denyCurrentBranch',
                            'ignore'])


### PR DESCRIPTION
Currently, when using one deployment with a prefix and one without, the deployment including the prefix will delete versions of the same name in the deployment without a prefix.

The fix is to use the deploy prefix when deleting the previous version and aliases.

## Before

```console
$ mike deploy --deploy-prefix prefix 1.0.0
$ mike deploy 1.0.0
$ git ls-tree -d -r --name-only gh-pages
1.0.0
1.0.0/css
1.0.0/img
1.0.0/js
1.0.0/search
1.0.0/webfonts
prefix
prefix/1.0.0
prefix/1.0.0/css
prefix/1.0.0/img
prefix/1.0.0/js
prefix/1.0.0/search
prefix/1.0.0/webfonts
$ : Command below mistakenly deletes the top level 1.0.0/ directory
$ mike deploy --deploy-prefix prefix 1.0.0
$ git ls-tree -d -r --name-only gh-pages
prefix
prefix/1.0.0
prefix/1.0.0/css
prefix/1.0.0/img
prefix/1.0.0/js
prefix/1.0.0/search
prefix/1.0.0/webfonts
```

## After

```console
$ mike deploy --deploy-prefix prefix 1.0.0
$ mike deploy 1.0.0
$ git ls-tree -d -r --name-only gh-pages
1.0.0
1.0.0/css
1.0.0/img
1.0.0/js
1.0.0/search
1.0.0/webfonts
prefix
prefix/1.0.0
prefix/1.0.0/css
prefix/1.0.0/img
prefix/1.0.0/js
prefix/1.0.0/search
prefix/1.0.0/webfonts
$ mike deploy --deploy-prefix prefix 1.0.0
$ git ls-tree -d -r --name-only gh-pages
1.0.0
1.0.0/css
1.0.0/img
1.0.0/js
1.0.0/search
1.0.0/webfonts
prefix
prefix/1.0.0
prefix/1.0.0/css
prefix/1.0.0/img
prefix/1.0.0/js
prefix/1.0.0/search
prefix/1.0.0/webfonts
```