### PR TITLE
Add trailing slash to site_url

### DIFF
--- a/mike/mkdocs_plugin.py
+++ b/mike/mkdocs_plugin.py
@@ -46,7 +46,7 @@ class MikePlugin(BasePlugin):
         if version and config.get('site_url'):
             if self.config['canonical_version'] is not None:
                 version = self.config['canonical_version']
-            config['site_url'] = urljoin(config['site_url'], version)
+            config['site_url'] = urljoin(config['site_url'], version) + '/'
 
     def on_files(self, files, config):
         if not self.config['version_selector']:

--- a/test/unit/test_mkdocs_plugin.py
+++ b/test/unit/test_mkdocs_plugin.py
@@ -34,7 +34,7 @@ class TestMkdocsPluginOnConfig(PluginTest):
         with mock.patch('os.environ', {docs_version_var: '1.0'}):
             config = {'site_url': 'https://example.com/'}
             self.make_plugin().on_config(config)
-            self.assertEqual(config['site_url'], 'https://example.com/1.0')
+            self.assertEqual(config['site_url'], 'https://example.com/1.0/')
 
     def test_no_site_url(self):
         with mock.patch('os.environ', {docs_version_var: '1.0'}):
@@ -46,7 +46,7 @@ class TestMkdocsPluginOnConfig(PluginTest):
         with mock.patch('os.environ', {docs_version_var: '1.0'}):
             config = {'site_url': 'https://example.com/'}
             self.make_plugin(canonical_version='latest').on_config(config)
-            self.assertEqual(config['site_url'], 'https://example.com/latest')
+            self.assertEqual(config['site_url'], 'https://example.com/latest/')
 
         with mock.patch('os.environ', {docs_version_var: '1.0'}):
             config = {'site_url': 'https://example.com/'}


### PR DESCRIPTION
`site_url` has to end with a trailing slash, because when MkDocs processes the Jinja2 templates, it will embed a script tag into the final html:
```js
<script id="__config" type="application/json">{"base": "/some/path/4.1.1", ...}</script>
```

The JS-relevant part of mike then handles this as follows `fetch(ABS_BASE_URL + "../versions.json")`
or, if you look at the actual js-bundle:
`new URL("../versions.json", t.base)`

And if `t.base` doesn't end with a trailing slash, the last component is completely ignored, which is obviously not what we want:
```
new URL("../versions.json", "https://example.com/some/path/4.1.1")
// expected: https://example.com/some/path/versions.json
// actual:   https://example.com/some/versions.json
```

Note that I'm not well versed in the MkDocs/mike codebases, I might've overlooked something, but my gut feeling says this might be correct