### PR TITLE
Fix CVE-2024-5569: Pin zipp >= 3.19.1 to address infinite loop vulnerability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,8 @@ setup(
 
     install_requires=(['importlib_metadata', 'importlib_resources',
                        'jinja2 >= 2.7', 'mkdocs >= 1.0', 'pyparsing >= 3.0',
-                       'pyyaml >= 5.1', 'pyyaml_env_tag', 'verspec']),
+                       'pyyaml >= 5.1', 'pyyaml_env_tag', 'verspec',
+                       'zipp >= 3.19.1']),
     extras_require={
         'dev': ['coverage', 'flake8 >= 3.0', 'flake8-quotes', 'shtab'],
         'test': ['coverage', 'flake8 >= 3.0', 'flake8-quotes', 'shtab'],


### PR DESCRIPTION
In reference to GH issue: Security: mike@2.1.3 introduces vulnerable zipp dependency (CVE-2024-5569). Go to issue for details

We need this one in a release if possible. 

Thanks in advance